### PR TITLE
Replace neoline invokeMulti with invokeMultiple

### DIFF
--- a/packages/wallets/neoline/src/adapter.ts
+++ b/packages/wallets/neoline/src/adapter.ts
@@ -184,7 +184,7 @@ export class NeoLineWalletAdapter extends BaseWalletAdapter {
 		if (!client) throw new WalletNotConnectedError();
 
 		try {
-			const response = await client.invokeMulti({
+			const response = await client.invokeMultiple({
 				invokeArgs: request.invocations,
 				signers: request.signers ? this._signers(request.signers) : [],
 				fee: request.fee,

--- a/packages/wallets/neoline/src/utils/neoline.ts
+++ b/packages/wallets/neoline/src/utils/neoline.ts
@@ -118,7 +118,7 @@ export interface NeoLineN3Interface {
 		params: NeoLineInvokeReadInvocation & NeoLineInvokeWriteInvocation & { signers: NeoLineSigner[] },
 	): Promise<NeoLineWriteInvocationResult>;
 
-	invokeMulti(
+	invokeMultiple(
 		params: { invokeArgs: NeoLineInvokeReadInvocation[] } & NeoLineInvokeWriteInvocation & { signers: NeoLineSigner[] },
 	): Promise<NeoLineWriteInvocationResult>;
 }


### PR DESCRIPTION
The call to invoke multiple functions for neoline should be invokeMultiple instead of invokeMulti
https://neoline.io/dapi/N3.html#invokeMultiple

Error when using invokeMulti:
TypeError: client.invokeMulti is not a function