### PR TITLE
Setup support for cjs, esm module systems and build both

### DIFF
--- a/packages/core/base/package.json
+++ b/packages/core/base/package.json
@@ -6,7 +6,15 @@
 	"license": "Apache-2.0",
 	"sideEffects": false,
 	"main": "lib/index.js",
+	"module": "lib/esm/index.js",
 	"types": "lib/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./lib/index.d.ts",
+			"import": "./lib/esm/index.js",
+			"require": "./lib/index.js"
+		}
+	},
 	"files": [
 		"lib",
 		"src",
@@ -17,7 +25,7 @@
 	},
 	"scripts": {
 		"clean": "shx rm -rf lib/*",
-		"build": "yarn clean && tsc"
+		"build": "yarn clean && tsc --build tsconfig.json tsconfig.esm.json"
 	},
 	"dependencies": {
 		"eventemitter3": "^4.0.7"

--- a/packages/core/base/tsconfig.esm.json
+++ b/packages/core/base/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./lib/esm",
+    "module": "esnext"
+  }
+}

--- a/packages/core/react/package.json
+++ b/packages/core/react/package.json
@@ -6,8 +6,16 @@
 	"license": "Apache-2.0",
 	"sideEffects": false,
 	"main": "lib/index.js",
+	"module": "lib/esm/index.js",
 	"esnext": "lib/index.js",
 	"types": "lib/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./lib/index.d.ts",
+			"import": "./lib/esm/index.js",
+			"require": "./lib/index.js"
+		}
+	},
 	"files": [
 		"lib",
 		"src",
@@ -18,7 +26,7 @@
 	},
 	"scripts": {
 		"clean": "shx rm -rf lib/*",
-		"build": "yarn clean && tsc"
+		"build": "yarn clean && tsc --build tsconfig.json tsconfig.esm.json"
 	},
 	"peerDependencies": {
 		"@rentfuse-labs/neo-wallet-adapter-base": "^0.4.0",

--- a/packages/core/react/tsconfig.esm.json
+++ b/packages/core/react/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./lib/esm",
+    "module": "esnext"
+  }
+}

--- a/packages/core/wallets/package.json
+++ b/packages/core/wallets/package.json
@@ -6,8 +6,16 @@
 	"license": "Apache-2.0",
 	"sideEffects": false,
 	"main": "lib/index.js",
+	"module": "lib/esm/index.js",
 	"esnext": "lib/index.js",
 	"types": "lib/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./lib/index.d.ts",
+			"import": "./lib/esm/index.js",
+			"require": "./lib/index.js"
+		}
+	},
 	"files": [
 		"lib",
 		"src",
@@ -18,7 +26,7 @@
 	},
 	"scripts": {
 		"clean": "shx rm -rf lib/*",
-		"build": "yarn clean && tsc"
+		"build": "yarn clean && tsc --build tsconfig.json tsconfig.esm.json"
 	},
 	"dependencies": {
 		"@rentfuse-labs/neo-wallet-adapter-walletconnect": "^0.4.0",

--- a/packages/core/wallets/tsconfig.esm.json
+++ b/packages/core/wallets/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./lib/esm",
+    "module": "esnext"
+  }
+}

--- a/packages/ui/ant-design/package.json
+++ b/packages/ui/ant-design/package.json
@@ -5,8 +5,16 @@
 	"repository": "https://github.com/rentfuse-labs/neo-wallet-adapter",
 	"license": "Apache-2.0",
 	"main": "lib/index.js",
+	"module": "lib/esm/index.js",
 	"esnext": "lib/index.js",
 	"types": "lib/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./lib/index.d.ts",
+			"import": "./lib/esm/index.js",
+			"require": "./lib/index.js"
+		}
+	},
 	"files": [
 		"lib",
 		"src",
@@ -18,7 +26,7 @@
 	},
 	"scripts": {
 		"clean": "shx rm -rf lib/*",
-		"build": "yarn clean && tsc"
+		"build": "yarn clean && tsc --build tsconfig.json tsconfig.esm.json"
 	},
 	"peerDependencies": {
 		"@ant-design/icons": "^4.6.3",

--- a/packages/ui/ant-design/tsconfig.esm.json
+++ b/packages/ui/ant-design/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./lib/esm",
+    "module": "esnext"
+  }
+}

--- a/packages/ui/react-ui/package.json
+++ b/packages/ui/react-ui/package.json
@@ -5,8 +5,16 @@
 	"repository": "https://github.com/rentfuse-labs/neo-wallet-adapter",
 	"license": "Apache-2.0",
 	"main": "lib/index.js",
+	"module": "lib/esm/index.js",
 	"esnext": "lib/index.js",
 	"types": "lib/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./lib/index.d.ts",
+			"import": "./lib/esm/index.js",
+			"require": "./lib/index.js"
+		}
+	},
 	"files": [
 		"lib",
 		"src",
@@ -18,7 +26,7 @@
 	},
 	"scripts": {
 		"clean": "shx rm -rf lib/*",
-		"build": "yarn clean && tsc"
+		"build": "yarn clean && tsc --build tsconfig.json tsconfig.esm.json"
 	},
 	"peerDependencies": {
 		"@rentfuse-labs/neo-wallet-adapter-base": "^0.4.0",

--- a/packages/ui/react-ui/tsconfig.esm.json
+++ b/packages/ui/react-ui/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./lib/esm",
+    "module": "esnext"
+  }
+}

--- a/packages/wallets/neoline/package.json
+++ b/packages/wallets/neoline/package.json
@@ -6,8 +6,16 @@
 	"license": "Apache-2.0",
 	"sideEffects": false,
 	"main": "lib/index.js",
+	"module": "lib/esm/index.js",
 	"esnext": "lib/index.js",
 	"types": "lib/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./lib/index.d.ts",
+			"import": "./lib/esm/index.js",
+			"require": "./lib/index.js"
+		}
+	},
 	"files": [
 		"lib",
 		"src",
@@ -18,7 +26,7 @@
 	},
 	"scripts": {
 		"clean": "shx rm -rf lib/*",
-		"build": "yarn clean && tsc"
+		"build": "yarn clean && tsc --build tsconfig.json tsconfig.esm.json"
 	},
 	"dependencies": {},
 	"peerDependencies": {

--- a/packages/wallets/neoline/tsconfig.esm.json
+++ b/packages/wallets/neoline/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./lib/esm",
+    "module": "esnext"
+  }
+}

--- a/packages/wallets/o3/package.json
+++ b/packages/wallets/o3/package.json
@@ -6,8 +6,16 @@
 	"license": "Apache-2.0",
 	"sideEffects": false,
 	"main": "lib/index.js",
+	"module": "lib/esm/index.js"
 	"esnext": "lib/index.js",
 	"types": "lib/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./lib/index.d.ts",
+			"import": "./lib/esm/index.js",
+			"require": "./lib/index.js"
+		}
+	},
 	"files": [
 		"lib",
 		"src",
@@ -18,7 +26,7 @@
 	},
 	"scripts": {
 		"clean": "shx rm -rf lib/*",
-		"build": "yarn clean && tsc"
+		"build": "yarn clean && tsc --build tsconfig.json tsconfig.esm.json"
 	},
 	"dependencies": {
 		"neo3-dapi": "^1.0.1"

--- a/packages/wallets/o3/tsconfig.esm.json
+++ b/packages/wallets/o3/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./lib/esm",
+    "module": "esnext"
+  }
+}

--- a/packages/wallets/onegate/package.json
+++ b/packages/wallets/onegate/package.json
@@ -6,8 +6,16 @@
 	"license": "Apache-2.0",
 	"sideEffects": false,
 	"main": "lib/index.js",
+	"module": "lib/esm/index.js"
 	"esnext": "lib/index.js",
 	"types": "lib/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./lib/index.d.ts",
+			"import": "./lib/esm/index.js",
+			"require": "./lib/index.js"
+		}
+	},
 	"files": [
 		"lib",
 		"src",
@@ -18,7 +26,7 @@
 	},
 	"scripts": {
 		"clean": "shx rm -rf lib/*",
-		"build": "yarn clean && tsc"
+		"build": "yarn clean && tsc --build tsconfig.json tsconfig.esm.json"
 	},
 	"dependencies": {
 		"@neongd/neo-dapi": "1.0.1",

--- a/packages/wallets/onegate/tsconfig.esm.json
+++ b/packages/wallets/onegate/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./lib/esm",
+    "module": "esnext"
+  }
+}

--- a/packages/wallets/walletconnect/package.json
+++ b/packages/wallets/walletconnect/package.json
@@ -6,8 +6,16 @@
 	"license": "Apache-2.0",
 	"sideEffects": false,
 	"main": "lib/index.js",
+	"module": "lib/esm/index.js"
 	"esnext": "lib/index.js",
 	"types": "lib/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./lib/index.d.ts",
+			"import": "./lib/esm/index.js",
+			"require": "./lib/index.js"
+		}
+	},
 	"files": [
 		"lib",
 		"src",
@@ -18,7 +26,7 @@
 	},
 	"scripts": {
 		"clean": "shx rm -rf lib/*",
-		"build": "yarn clean && tsc"
+		"build": "yarn clean && tsc --build tsconfig.json tsconfig.esm.json"
 	},
 	"dependencies": {
 		"@types/pino": "^6.3.11",

--- a/packages/wallets/walletconnect/tsconfig.esm.json
+++ b/packages/wallets/walletconnect/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./lib/esm",
+    "module": "esnext"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
 		"noEmitOnError": true,
 		"stripInternal": true,
 		"target": "es6",
-		"module": "esnext",
+		"module": "commonjs",
 		"moduleResolution": "node",
 		"jsx": "react",
 		"strict": true,


### PR DESCRIPTION
Thank you for the great project. I was able to easily link wallet with my project.

However, a transpile configuration of webpack is required when project using cjs module system. ([like you provided](https://github.com/rentfuse-labs/neo-wallet-adapter/blob/4c42eef20850a32f18dc9186b28891ecfabe89b1/packages/starter/nextjs-starter/next.config.js#L2))
If both module systems, including cjs, are supported in this project, users of the this library don't need to set anything up.

Therefore, this PR has been modified to support both module systems.

Thank you.